### PR TITLE
Fixing link to data-sources lab

### DIFF
--- a/content/en/docs/04/1-versions.md
+++ b/content/en/docs/04/1-versions.md
@@ -8,7 +8,7 @@ onlyWhen: azure
 
 ## Preparation
 
-Finish the [Data Sources exercise](../03/4-data-sources.md) and copy the directory:
+Finish the [Data Sources exercise]({{< relref "4-data-sources.md" >}}) and copy the directory:
 
 ```bash
 cp -r $LAB_ROOT/basics/data_sources $LAB_ROOT/intermediate/versions


### PR DESCRIPTION
Using the Hugo `relref` shortcode to link to the document.
A standard markdown link, would work as well (`[Data Sources exercise](../../03/4-data-sources/)`)